### PR TITLE
Create doc files

### DIFF
--- a/Documentation/composition.md
+++ b/Documentation/composition.md
@@ -1,0 +1,35 @@
+## Composition
+
+It's possible to compose selectors.
+
+``` css
+.className {
+  color: green;
+  background: red;
+}
+
+.otherClassName {
+  composes: className;
+  color: yellow;
+}
+```
+
+There can be multiple `composes` rules, but `composes` rules must be before other rules. Extending works only for local-scoped selectors and only if the selector is a single class name. When a class name composes another class name, the **CSS Module** exports both class names for the local class. This can add up to multiple class names.
+
+It's possible to compose multiple classes with `composes: classNameA classNameB;`.
+
+## Dependencies
+
+It's possible to compose class names from other **CSS Modules**.
+
+``` css
+.otherClassName {
+  composes: className from "./style.css";
+}
+```
+
+Note that when composing multiple classes from different files the order of appliance is *undefined*. Make sure to not define different values for the same property in multiple class names from different files when they are composed in a single class.
+
+Note that composing should not form a circular dependency. Elsewise it's *undefined* whether properties of a rule override properties of a composed rule. The module system may emit an error.
+
+Best if classes do a single thing and dependencies are hierarchic.

--- a/Documentation/exceptions.md
+++ b/Documentation/exceptions.md
@@ -1,0 +1,140 @@
+## Exceptions
+
++ [global and local scopes](#Global-Local-scopes)
++ [pseudo-selectors](#pseudo-selectors-+-tags)
+
+#### Global Local Scopes
+`:global` switches to global scope for the current selector resp. identifier. `:global(.xxx)` resp. `@keyframes :global(xxx)` declares a the stuff in brackets in the global scope.
+
+Similar `:local` and `:local(...)` for local scope.
+
+If the selector is switched into global mode, global mode is also activated for the rules. (this allows to make `animation: abc;` local)
+
+Example: `.localA :global .global-b .global-c :local(.localD.localE) .global-d`
+
+#### Pseudo-Selectors + tags
+Ok, so. Yes. This is a problem. Let me give you some background (maybe you're already across this but for other readers of this issue):
+
+composes works by exporting multiple classnames from the CSS. So, when you have
+
+```css
+.foo {
+  color: red;
+}
+.bar {
+  composes: foo;
+  background-color: blue;
+}
+
+import styles from "./foo.css";
+
+return "<p class='${styles.bar}'>Content</p>"
+```
+
+You get the following ICSS:
+
+```css
+:export {
+  foo: foo_98812cadf;
+  bar: foo_98812cadf bar_312cbca63;
+}
+.foo_98812cadf {
+  color: red;
+}
+.bar_312cbca63 {
+  background-color: blue;
+}
+```
+
+So, your HTML renders out as `<p class='foo_98812cadf bar_312cbca63'>Content</p>` and you get all of `.foo` and `.bar` styles. But the only way that works is through classes. Think of composes as an instruction to JavaScript to include this extra class whenever you reference this one. It relies on dynamic markup to work.
+
+So if you don't have control over the markup being injected then composition doesn't work.
+`.foo :global(p)` will still give you localisation, of course, but if you're building your whole site using composition that's not ideal.
+
+I actually faced this exact problem and wrote a monstrous JSPM loader for it. It parses the markdown as YAML (for frontmatter), then markdown then JSX, then returns an ES6 function that accepts a styles object. I think. I can never remember, I wanted to tidy it up and release it but it breaks if I touch it...
+
+It gets used here and lets me do cool stuff with inline JSX in markdown:
+
+But I digress, back to the issue at hand.
+
+Theoretically, you could write a runtime JS component that gave you this more advanced behaviour, where it watches the live DOM and attaches classes based on these more advanced rules. That could be kind of neat, but at this stage it's not something I'm going to work on. For one, I am trying to avoid using descendent selectors & bare tags as much as possible, except for contextual overrides that don't care about the nature of the things they're overriding. E.g:
+
+```css
+.MyComponent {
+  > * {
+    margin-top: 1rem;
+  }
+  > :first-child {
+    margin-top: 0;
+  }
+}
+```
+
+Secondly, if you add a runtime dependency you need to be damn careful not to break server-side rendering. Because all the React SSR stuff already evaluates the render tree, injecting classnames there works really nicely. And since we're using plain-old-CSS, we get pseudo-selectors like :hover for free (Radium has problems with that). I think we can do it, but I'm not sure if it's worth it. And if we want to support traditional stuff like Rails (which we should!)
+
+Probably should also point out that the following usages of composes don't work for the same reasons:
+
+```css
+.foo .bar {
+  composes: different-when-nested;
+}
+@media (max-width: 599px) {
+  .bar {
+    composes: something-on-small-breakpoint;
+  }
+
+}
+The media query one, at least, has a decent fallback:
+
+/* A class can use media queries then get composed */
+.headline {
+  font-size: 4rem;
+}
+
+@media (max-width: 599px) {
+  .headline {
+    font-size: 3rem;
+  }
+}
+
+/* You can use suffixes like Tachyons/Basscss */
+.foo {
+  color: red;
+}
+
+@media (max-width: 599px) {
+  .foo--small {
+    color: red;
+  }
+}
+
+.bar {
+  composes: headline foo--small;
+}
+```
+
+The thing I like about this is that we're building our own abstractions on top of the basic CSS mechanisms. I see composes as constrained, yes, but it feels like it's worth embracing this constraint for the time being to see where it leads us :)
+
+##### solution:
+```css
+.icon {
+  /* maybe something here, maybe nothing */
+}
+
+.icon::before {
+  /* style to add an icon before a button*/
+  position: absolute;
+  top: 50%;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  margin-top: -10px;
+  font-size: 14px;
+}
+
+.button {
+  composes: button from './component/button.css';
+  composes: icon;
+  color: #fff;
+}
+````

--- a/Documentation/history.md
+++ b/Documentation/history.md
@@ -1,0 +1,12 @@
+## History
+
+* 04/2015: `placeholders` feature in css-loader (webpack) allows local scoped selectors (later renamed to `local scope`) by @sokra
+* 05/2015: `postcss-local-scope` enables `local scope` by default (see [blog post](https://medium.com/seek-ui-engineering/the-end-of-global-css-90d2a4a06284)) by @markdalgleish
+* 05/2015: `extends` feature in css-loader allow to compose local or imported class names by @sokra
+* 05/2015: First CSS Modules spec document and github organization with @sokra, @markdalgleish and @geelen
+* 06/2015: `extends` renamed to `composes`
+* 06/2015: PostCSS transformations to tranform CSS Modules into a intermediate format (ICSS)
+* 06/2015: Spec for ICSS as common implementation format for multiple module systems by @geelen
+* 06/2015: Implementation for jspm by @geelen and @guybedford
+* 06/2015: Implementation for browserify by @joshwnj, @joshgillies and @markdalgleish
+* 06/2015: webpack's css-loader implementation  updated to latest spec by @sokra

--- a/Documentation/implementations.md
+++ b/Documentation/implementations.md
@@ -1,0 +1,15 @@
+
+## Implementations
+
+### webpack
+
+Webpack's [css-loader](https://github.com/webpack/css-loader) in module mode replaces every local-scoped identifier with a global unique name (hashed from module name and local identifier by default) and exports the used identifer.
+
+Extending adds the source class name(s) to the exports.
+
+Extending from other modules first imports the other module and than adds the class name(s) to the exports.
+
+
+### browserify
+
+Browserify's (css-modulesify)[https://github.com/css-modules/css-modulesify].

--- a/Documentation/preprocessors.md
+++ b/Documentation/preprocessors.md
@@ -1,0 +1,13 @@
+## Usage with preprocessors
+
+Preprocessors can make it easy to define a block global or local.
+
+i. e. with less.js
+
+``` less
+:global {
+  .global-class-name {
+    color: green;
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -22,71 +22,6 @@ import styles from "./style.css";
 element.innerHTML = '<div class="' + styles.className + '">';
 ```
 
-## Naming
-
-For local class names camelCase naming is recommended, but not enforced.
-
-## Exceptions
-
-`:global` switches to global scope for the current selector resp. identifier. `:global(.xxx)` resp. `@keyframes :global(xxx)` declares a the stuff in brackets in the global scope.
-
-Similar `:local` and `:local(...)` for local scope.
-
-If the selector is switched into global mode, global mode is also activated for the rules. (this allows to make `animation: abc;` local)
-
-Example: `.localA :global .global-b .global-c :local(.localD.localE) .global-d`
-
-## Composition
-
-It's possible to compose selectors.
-
-``` css
-.className {
-  color: green;
-  background: red;
-}
-
-.otherClassName {
-  composes: className;
-  color: yellow;
-}
-```
-
-There can be multiple `composes` rules, but `composes` rules must be before other rules. Extending works only for local-scoped selectors and only if the selector is a single class name. When a class name composes another class name, the **CSS Module** exports both class names for the local class. This can add up to multiple class names.
-
-It's possible to compose multiple classes with `composes: classNameA classNameB;`.
-
-## Dependencies
-
-It's possible to compose class names from other **CSS Modules**.
-
-``` css
-.otherClassName {
-  composes: className from "./style.css";
-}
-```
-
-Note that when composing multiple classes from different files the order of appliance is *undefined*. Make sure to not define different values for the same property in multiple class names from different files when they are composed in a single class.
-
-Note that composing should not form a circular dependency. Elsewise it's *undefined* whether properties of a rule override properties of a composed rule. The module system may emit an error.
-
-Best if classes do a single thing and dependencies are hierarchic.
-
-
-## Usage with preprocessors
-
-Preprocessors can make it easy to define a block global or local.
-
-i. e. with less.js
-
-``` less
-:global {
-  .global-class-name {
-    color: green;
-  }
-}
-```
-
 ## Why?
 
 **modular** and **reusable** CSS!
@@ -95,32 +30,13 @@ i. e. with less.js
 * Explicit dependencies.
 * No global scope.
 
-## Examples
+## Documentation
++ [Composition](Documentation/Composition.md)
++ [Exceptions](Documentation/Exceptions.md)
++ [Implementations](Documentation/Implementations.md)
++ [Preprocessors](Documentation/Preprocessors.md)
++ [History](Documentation/history.md)
 
+## Examples
 * [css-modules/webpack-demo](https://github.com/css-modules/webpack-demo)
 * [Theming](examples/theming.md)
-
-
-## History
-
-* 04/2015: `placeholders` feature in css-loader (webpack) allows local scoped selectors (later renamed to `local scope`) by @sokra
-* 05/2015: `postcss-local-scope` enables `local scope` by default (see [blog post](https://medium.com/seek-ui-engineering/the-end-of-global-css-90d2a4a06284)) by @markdalgleish
-* 05/2015: `extends` feature in css-loader allow to compose local or imported class names by @sokra
-* 05/2015: First CSS Modules spec document and github organization with @sokra, @markdalgleish and @geelen
-* 06/2015: `extends` renamed to `composes`
-* 06/2015: PostCSS transformations to tranform CSS Modules into a intermediate format (ICSS)
-* 06/2015: Spec for ICSS as common implementation format for multiple module systems by @geelen
-* 06/2015: Implementation for jspm by @geelen and @guybedford
-* 06/2015: Implementation for browserify by @joshwnj, @joshgillies and @markdalgleish
-* 06/2015: webpack's css-loader implementation  updated to latest spec by @sokra
-
-
-## Implementations
-
-### webpack
-
-Webpack's [css-loader](https://github.com/webpack/css-loader) in module mode replaces every local-scoped identifier with a global unique name (hashed from module name and local identifier by default) and exports the used identifer.
-
-Extending adds the source class name(s) to the exports.
-
-Extending from other modules first imports the other module and than adds the class name(s) to the exports.


### PR DESCRIPTION
I took a quick stab at breaking out the README into several smaller files like Exceptions, PreProcessors etc.
- [Composition](Documentation/Composition.md)
- [Exceptions](Documentation/Exceptions.md)
- [Implementations](Documentation/Implementations.md)
- [Preprocessors](Documentation/Preprocessors.md)
- [History](Documentation/history.md)
#### Why
- Make the README more readable (easier to find what you're looking for)
- Make space for more content (there's lots more that should go into the docs and splitting up a monoloth file makes it easier to see what's missing)
- Start consolidating discussions from the issues (I added an exception for psedoselectors and tags) based on #33
#### WIP
- this is a rough draft (I split kinda fast and wild) (please help me think through a good placement for files)
- the links to files and TOCs are probably bad (I can go back and clean that up)
