### PR TITLE
How to use css-modules with other global css

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ i. e. with less.js
 * [Theming](examples/theming.md)
 
 
+## How to use it with any other global css (bootstrap for example)
+
 ## History
 
 * 04/2015: `placeholders` feature in css-loader (webpack) allows local scoped selectors (later renamed to `local scope`) by @sokra


### PR DESCRIPTION
@markdalgleish @joshwnj
Initially I was trying to make two loaders working together 

```
{
      test: /\.less$/,
      loader: 'style!css?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!less'
})
```

```
{
      test: /\.less$/,
      loader: 'style!css!less'
})
```

and made an issue for this https://github.com/css-modules/css-modules/issues/59 
Bottom line of this was:
name all local css - *.module.(less|sass|whatever)
keep all global css - *.(less|sass|whatever)
and have these loaders

```
{
      test: /\.module.less$/,
      loader: 'style-loader!css-loader?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!less-loader'
}
{
      test: /^((?!\.module).)*less$/,
      loader: 'style!css!less'
}
```

This is ugly, but solves the problem on some level.
As @markdalgleish said there a lot caveats of having both global and local css, so I hope this PR could be a good place to discuss these caveats. The goal of this PR make reasonable FAQ on this matter.
