### PR TITLE
Updated angular docs with more actual examples

### DIFF
--- a/docs/using-css-modules-with-angular.md
+++ b/docs/using-css-modules-with-angular.md
@@ -18,8 +18,9 @@ angular.module('myApp').controller('MyController', ($scope) => {
 ```html
 <div ng-app="myApp">
   <div ng-controller="MyController">
-    <header ng-class="{{::styles.bacon}}">
-      <h1 ng-class="{{::styles.pancakes}}">
+    <header class="{{::styles.bacon + ' ' + styles.pancakes}}">
+      <h1 class="{{styles.pancakes}}">pancakes (2-way binding)</h1>
+      <h1 ng-class="styles.bacon">bacon</h1>
         <!-- ... --->
     </header>
   </div>


### PR DESCRIPTION
In current angular 1.5 ng-class won't work with ``{{expression}}``