### PR TITLE
Add simple :global example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ For local class names camelCase naming is recommended, but not enforced.
 
 Similarly, `:local` and `:local(...)` for local scope.
 
+Example: `:global(.some-selector) { ... }`
+
 If the selector is switched into global mode, global mode is also activated for the rules. (This allows us to make `animation: abc;` local.)
 
 Example: `.localA :global .global-b .global-c :local(.localD.localE) .global-d`


### PR DESCRIPTION
I wasn't able to understand how to use `:global` simply, without a preprocessor, as the README was missing a simple example and I couldn't find anything in the extended docs. I think this will help others in a similar situation.