### PR TITLE
Add Ember addon to language integrations

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -31,3 +31,7 @@ If you're using React, CSS Modules is a great fit. [react-css-modules](https://g
 ### Deku
 
 If you're using Deku, CSS Modules is an awesome fit. [deku-css-modules](https://github.com/StevenIseki/deku-css-modules) allows for easy integration of CSS Modules & Deku.
+
+### Ember
+
+If you're using Ember, [ember-css-modules](https://github.com/salsify/ember-css-modules) includes the usage of `local-class` attribute for easy integration of CSS modules & Ember.


### PR DESCRIPTION
## Docs
### Add Ember addon to language integrations
[`ember-css-modules`](https://github.com/salsify/ember-css-modules) is a pretty nice addon to easily use CSS Modules in an Ember app.