### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # CSS Modules
 
-A **CSS Module** is a CSS file where all class names and animation names are scoped locally by default. All URLs (`url(...)`) and `@imports` are in module request format (`./xxx` and `../xxx` means relative, `xxx` and `xxx/yyy` means in modules folder, i.e. in `node_modules`).
+A **CSS Module** is a CSS file where all class names and animation names are scoped locally by default. All URLs (`url(...)`) and `@imports` are in module request format (`./xxx` and `../xxx` means relative, `xxx` and `xxx/yyy` means in modules folder, i.e. in `node_modules`, `.yarn`, etc.).
 
 CSS Modules compile to a low-level interchange format called ICSS (or [Interoperable CSS](https://github.com/css-modules/icss)) but are written like normal CSS files:
 
@@ -22,7 +22,7 @@ When importing a **CSS Module** from a JavaScript Module, it exports an object w
 ```js
 import styles from './style.css';
 
-element.innerHTML = '<div class="' + styles.className + '">';
+element.innerHTML = `<div class="${styles.className}">`;
 ```
 
 ## Table of Contents

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -102,7 +102,7 @@ Similarly, `:local` and `:local(...)` for local scope.
 
 If the selector is switched into global mode, global mode is also activated for the rules. (This allows us to make `animation: abc;` local.)
 
-Example: ``
+Example:
 
 ```css
 .localA :global .global-b .global-c :local(.localD.localE) .global-d {

--- a/docs/import-multiple-css-modules.md
+++ b/docs/import-multiple-css-modules.md
@@ -11,7 +11,7 @@ You can import multiple CSS Modules into a component or function using `Object.a
 For example, if you import a button CSS Module to your `Demo` component, add this to the components default styles.
 
 ```js
-let styles = {};
+const styles = {};
 import demo from './Demo.css';
 import fancyButton from 'css-fancy-button';
 Object.assign(styles, fancyButton, demo);

--- a/docs/import-multiple-css-modules.md
+++ b/docs/import-multiple-css-modules.md
@@ -33,7 +33,7 @@ A full example of a demo component with 2 css modules imported.
 
 ```jsx
 import React from 'react';
-let styles = {};
+const styles = {};
 import demo from './Demo.css';
 import fancyButton from 'css-fancy-button';
 Object.assign(styles, fancyButton, demo);

--- a/docs/local-scope.md
+++ b/docs/local-scope.md
@@ -10,10 +10,13 @@ CSS Modules have class selectors scoped locally by default. For example, the fol
 
 ```css
 .backdrop {
+  /* ... */
 }
 .prompt {
+  /* ... */
 }
 .pullquote {
+  /* ... */
 }
 ```
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -44,7 +44,7 @@ import themeA from 'component/theme-a.css';
 import themeB from 'component/theme-b.css';
 import customTheme from './custom-theme.css';
 
-import {Component} from 'component';
+import { Component } from 'component';
 
 <Component theme={themeA} />
 <Component theme={themeB} />


### PR DESCRIPTION
1. According to the previous formulation, it seemed that only node_modules were supported, although it works fine with others
```diff
- A **CSS Module** is a CSS file where all class names and animation names are scoped locally by default. All URLs (`url(...)`) and `@imports` are in module request format (`./xxx` and `../xxx` means relative, `xxx` and `xxx/yyy` means in modules folder, i.e. in `node_modules`).
+ A **CSS Module** is a CSS file where all class names and animation names are scoped locally by default. All URLs (`url(...)`) and `@imports` are in module request format (`./xxx` and `../xxx` means relative, `xxx` and `xxx/yyy` means in modules folder, i.e. in `node_modules`, `.yarn`, etc.).
```

2. It looks better and more familiar in 2024
```diff
- element.innerHTML = '<div class="' + styles.className + '">';
+ element.innerHTML = `<div class="${styles.className}">`;
```

3. Example: `` - just typo

4. It will be cleaner this way
```diff
- let styles = {};
+ const styles = {};
```

5. Reduction to a common code style (like [here](https://github.com/css-modules/css-modules/blob/master/docs/composition.md#exceptions))
```diff
- .backdrop {
- }
+ .backdrop {
+  /* ... */
+ }
```

6. Reduction to a common code style (like [here](https://github.com/css-modules/css-modules/blob/master/docs/import-multiple-css-modules.md#import-multiple-css-modules-into-a-component))
```diff
- import {Component} from 'component';
+ import { Component } from 'component';
```