### PR TITLE
Explained how to get started for Ember projects built with Embroider

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -56,6 +56,8 @@ Create React App supports CSS Modules. [Learn more](https://create-react-app.dev
 
 Ember supports CSS Modules through `ember-css-modules`. [Learn more](https://github.com/salsify/ember-css-modules).
 
+For projects built with Embroider, Ember provides `embroider-css-modules`. [Learn more](https://github.com/ijlee2/embroider-css-modules).
+
 ### Next.js
 
 Next.js supports CSS Modules for both webpack and Turbopack (`next dev --turbo`). [Learn more](https://nextjs.org/docs/app/building-your-application/styling/css-modules).


### PR DESCRIPTION
## Background

Hello. In #379, [`ember-css-modules`](https://github.com/salsify/ember-css-modules) was provided as a solution for introducing CSS modules to Ember projects.

This library has indeed been the go-to library for years, but is currently known to be incompatible with Ember projects built with [Embroider](https://github.com/embroider-build/embroider) on the strictest settings. I believe, this year and next, more Ember teams will incrementally migrate their projects to use Embroider.


## What changed?

I updated the `get-started` page so that, under Ember, it also lists [`embroider-css-modules`](https://github.com/ijlee2/embroider-css-modules) as a solution.

This project takes the approach of using plugins from the wider JavaScript community to implement CSS modules. Through CI, it is shown to be compatible with Embroider on the strictest settings.
